### PR TITLE
TJN-50: Fix/Clear out old scripts from package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,13 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "json-server db.json --port 3001",
-    "generate:feature": "tsx scaffolder/generateFeature.ts",
-    "generate:hook": "tsx scaffolder/scripts/generateHook.ts",
-    "generate:api": "tsx scaffolder/scripts/generateApi.ts",
-    "generate:slice": "tsx scaffolder/scripts/generateSlice.ts",
-    "generate:type": "tsx scaffolder/scripts/generateTypes.ts",
-    "generate:component": "tsx scaffolder/scripts/generateComponent.ts"
+    "server": "json-server db.json --port 3001"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.7",


### PR DESCRIPTION
### Description
There were left over generate scripts from the template that we're not using

### Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement

### How can this be tested (Please include visual illustrations if need be)
- scripts in package.json before:
<img width="1242" height="846" alt="image" src="https://github.com/user-attachments/assets/9e03be16-9a54-4521-bf4e-b1d59311dcf3" />

- scripts after:
<img width="870" height="666" alt="image" src="https://github.com/user-attachments/assets/8f90251d-5981-4fba-a87e-a7618624b1bd" />


### Documentation update checklist
- [x] I have made corresponding changes to the documentation
- [ ] No documentation changes required


### Link to corresponding ticket or issue
- [Jira Link](https://yassahr.atlassian.net/jira/software/projects/TJN/list?selectedIssue=TJN-50)