### PR TITLE
TJN-45 Store persist

### DIFF
--- a/client/src/features/auth/stores/authStore.ts
+++ b/client/src/features/auth/stores/authStore.ts
@@ -15,7 +15,7 @@ interface AuthStore extends AuthResponseT {
 
 // good one
 export const useAuthStore = createLocalPersistStore<AuthStore>(
-  (set, get) => ({
+  (set) => ({
     token: "",
     user: {
       firstName: "",

--- a/client/src/features/auth/stores/authStore.ts
+++ b/client/src/features/auth/stores/authStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { AuthResponseT, UserProfileT } from "@/features/auth/";
-
+import { createLocalStore } from "@/lib/utils";
 interface AuthStore extends AuthResponseT {
   token: string;
   user: {
@@ -14,7 +14,7 @@ interface AuthStore extends AuthResponseT {
   initAuth: (auth: AuthResponseT) => void;
 }
 
-export const useAuthStore = create<AuthStore>((set) => ({
+const authStore = create<AuthStore>((set, get) => ({
   token: "",
   user: {
     firstName: "",
@@ -39,3 +39,39 @@ export const useAuthStore = create<AuthStore>((set) => ({
     }));
   },
 }));
+
+// good one
+// export const useAuthStore = create(
+//   persist<AuthStore>(
+//     (set, get) => ({
+//       token: "",
+//       user: {
+//         firstName: "",
+//         lastName: "",
+//         isAdmin: false,
+//         id: "",
+//         email: "",
+//       },
+//       setUserToken: (token: string) => set(() => ({ token })),
+//       setUser: (user: UserProfileT) => set(() => ({ user })),
+
+//       initAuth: (auth: AuthResponseT) => {
+//         set(() => ({
+//           token: auth.token,
+//           user: {
+//             id: auth.user.id,
+//             firstName: auth.user.firstName,
+//             lastName: auth.user.lastName,
+//             email: auth.user.email,
+//             isAdmin: auth.user.isAdmin,
+//           },
+//         }));
+//       },
+//     }),
+//     { name: "authStore", storage: createJSONStorage(() => localStorage) }
+//   )
+// );
+
+export const useAuthStore = () => {
+  return createLocalStore<AuthStore>(authStore, "authStore");
+};

--- a/client/src/features/auth/stores/authStore.ts
+++ b/client/src/features/auth/stores/authStore.ts
@@ -1,6 +1,5 @@
-import { create } from "zustand";
 import { AuthResponseT, UserProfileT } from "@/features/auth/";
-import { createLocalStore } from "@/lib/utils";
+import { createLocalPersistStore } from "@/lib/utils";
 interface AuthStore extends AuthResponseT {
   token: string;
   user: {
@@ -14,64 +13,32 @@ interface AuthStore extends AuthResponseT {
   initAuth: (auth: AuthResponseT) => void;
 }
 
-const authStore = create<AuthStore>((set, get) => ({
-  token: "",
-  user: {
-    firstName: "",
-    lastName: "",
-    isAdmin: false,
-    id: "",
-    email: "",
-  },
-  setUserToken: (token: string) => set(() => ({ token })),
-  setUser: (user: UserProfileT) => set(() => ({ user })),
-
-  initAuth: (auth: AuthResponseT) => {
-    set(() => ({
-      token: auth.token,
-      user: {
-        id: auth.user.id,
-        firstName: auth.user.firstName,
-        lastName: auth.user.lastName,
-        email: auth.user.email,
-        isAdmin: auth.user.isAdmin,
-      },
-    }));
-  },
-}));
-
 // good one
-// export const useAuthStore = create(
-//   persist<AuthStore>(
-//     (set, get) => ({
-//       token: "",
-//       user: {
-//         firstName: "",
-//         lastName: "",
-//         isAdmin: false,
-//         id: "",
-//         email: "",
-//       },
-//       setUserToken: (token: string) => set(() => ({ token })),
-//       setUser: (user: UserProfileT) => set(() => ({ user })),
+export const useAuthStore = createLocalPersistStore<AuthStore>(
+  (set, get) => ({
+    token: "",
+    user: {
+      firstName: "",
+      lastName: "",
+      isAdmin: false,
+      id: "",
+      email: "",
+    },
+    setUserToken: (token: string) => set(() => ({ token })),
+    setUser: (user: UserProfileT) => set(() => ({ user })),
 
-//       initAuth: (auth: AuthResponseT) => {
-//         set(() => ({
-//           token: auth.token,
-//           user: {
-//             id: auth.user.id,
-//             firstName: auth.user.firstName,
-//             lastName: auth.user.lastName,
-//             email: auth.user.email,
-//             isAdmin: auth.user.isAdmin,
-//           },
-//         }));
-//       },
-//     }),
-//     { name: "authStore", storage: createJSONStorage(() => localStorage) }
-//   )
-// );
-
-export const useAuthStore = () => {
-  return createLocalStore<AuthStore>(authStore, "authStore");
-};
+    initAuth: (auth: AuthResponseT) => {
+      set(() => ({
+        token: auth.token,
+        user: {
+          id: auth.user.id,
+          firstName: auth.user.firstName,
+          lastName: auth.user.lastName,
+          email: auth.user.email,
+          isAdmin: auth.user.isAdmin,
+        },
+      }));
+    },
+  }),
+  "authStore"
+);

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,6 +1,22 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+import { create, StoreApi, UseBoundStore } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 
+//to handle combining class names with tailwind and clsx
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+//to create a local store with zustand and persist it to localStorage by passing store instance and store name
+export function createLocalStore<T>(
+  store: UseBoundStore<StoreApi<T>>,
+  storeName: string
+) {
+  return create(
+    persist(store, {
+      name: storeName,
+      storage: createJSONStorage(() => localStorage),
+    })
+  );
 }

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
-import { create, StoreApi, UseBoundStore } from "zustand";
+import { create, StateCreator } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 //to handle combining class names with tailwind and clsx
@@ -9,12 +9,12 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 //to create a local store with zustand and persist it to localStorage by passing store instance and store name
-export function createLocalStore<T>(
-  store: UseBoundStore<StoreApi<T>>,
+export function createLocalPersistStore<T>(
+  stateCreater: StateCreator<T>,
   storeName: string
 ) {
   return create(
-    persist<T>(store, {
+    persist<T>(stateCreater, {
       name: storeName,
       storage: createJSONStorage(() => localStorage),
     })

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -14,7 +14,7 @@ export function createLocalStore<T>(
   storeName: string
 ) {
   return create(
-    persist(store, {
+    persist<T>(store, {
       name: storeName,
       storage: createJSONStorage(() => localStorage),
     })


### PR DESCRIPTION
### Description
- add util that will return a local store persisted instance 
- update useAuthStore hook to use local storage persisted util
- change login user auth details now stored on local storage, mainly token and user profile for now

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ x] Improvement

### How can this be tested (Please include visual illustrations if need be)
- storing item in store that is persisted to local storage will create and entry in browser for the store under the local storage
<img width="1943" height="935" alt="image" src="https://github.com/user-attachments/assets/a712166a-b7eb-4fbc-8fe1-e2a101ab4f48" />


### Documentation update checklist
- [ ] I have made corresponding changes to the documentation
- [ x] No documentation changes required


### Link to corresponding ticket or issue
- https://yassahr.atlassian.net/browse/TJN-45