### PR TITLE
Tjn 36/service catalog availability pt2

### DIFF
--- a/server/src/controllers/availabilityController.ts
+++ b/server/src/controllers/availabilityController.ts
@@ -106,8 +106,9 @@ const getAvailableTechnicians = asyncHandler(
   async (req: Request, res: Response, next: NextFunction) => {
     const { service_id } = req.params;
     const { date, time_block } = req.query;
+    const TIME_BLOCK_OPTIONS = ['morning', 'afternoon', 'evening'];
 
-    if (typeof date !== 'string' || typeof time_block !== 'string') {
+    if (typeof date !== 'string' || TIME_BLOCK_OPTIONS.includes(time_block)) {
       res.status(400).json({
         error: 'Missing or invalid `date` or `time_block` query parameter',
       });

--- a/server/src/services/availabilityService.ts
+++ b/server/src/services/availabilityService.ts
@@ -60,4 +60,50 @@ async function getOpenTimeBlocks(serviceId: string, date: string) {
   return availabilityMap;
 }
 
-export { getUpcomingAvailableDatesByServiceId, getOpenTimeBlocks };
+async function getTechniciansByServiceDateAndTimeBlock(
+  serviceId: string,
+  date: string,
+  timeBlock: TimeBlock
+) {
+  try {
+    const technicians = await prismaClient.technician.findMany({
+      where: {
+        services: {
+          some: {
+            service_id: serviceId,
+          },
+        },
+        availabilities: {
+          some: {
+            available_date: date,
+            time_block: timeBlock,
+          },
+        },
+      },
+      select: {
+        id: true,
+        user: {
+          select: {
+            first_name: true,
+            last_name: true,
+          },
+        },
+        current_rating: true,
+      },
+    });
+
+    return technicians;
+  } catch (error: any) {
+    console.error(
+      `Error retrieving technicians for service ${serviceId} on ${date} during ${timeBlock}:`,
+      error
+    );
+    throw new Error('Failed to fetch available technicians.');
+  }
+}
+
+export {
+  getUpcomingAvailableDatesByServiceId,
+  getOpenTimeBlocks,
+  getTechniciansByServiceDateAndTimeBlock,
+};


### PR DESCRIPTION
### Description
- Introduce an endpoint where it GETs available technicians for that service, date, and time block

### Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Improvement

### How can this be tested (Please include visual illustrations if need be)
- Setup: 
   - `.env`'s `DATABASE_URL` is set pointing to prod's db
   - Spin up the server locally with `npm run dev`
   -   We will be making a request to `http://localhost:3000/api/availabilities/service/:service_id?date=YYYY-DD-MM&time_block=timeOfDay`
   - <img width="1181" height="609" alt="image" src="https://github.com/user-attachments/assets/ac91f1eb-f5eb-45af-933e-16ca903f595d" />
- Step 1 (Test 1)
   - endpoint: `http://localhost:3000/api/availabilities/service/:service_id?date=2025-09-10&time_block=afternoon` 
   - Params: (service_id: `2603cc04-26b9-4094-8196-ccedee8afe1e`, date: `2025-09-10`, time_block:`afternoon`),  put service_id's value in Path variable
   - Submit GET request
   - Returns info associated with bob.
   - <img width="765" height="437" alt="image" src="https://github.com/user-attachments/assets/bfe2453b-0d44-4a61-9e15-70b891069cfd" />

  

- Step 2 (Test 2)
    - endpoint: `http://localhost:3000/api/availabilities/service/:service_id?date=2025-09-12&time_block=afternoon` 
   - Params: (service_id: `6c79c3a0-9265-4b75-bc7b-a9e1fb9a9689`, date: `2025-09-12`, time_block:`afternoon`),  put service_id's value in Path variable
   - Submit GET request
   - Returns info associated with Loki.
 


### Documentation update checklist
- [x] I have made corresponding changes to the documentation
- [ ] No documentation changes required


### Link to corresponding ticket or issue
- [Jira Link](https://yassahr.atlassian.net/jira/software/projects/TJN/boards/1?selectedIssue=TJN-36)