### PR TITLE
TJN 89 backend misc work part1

### DIFF
--- a/server/prisma/migrations/20250810012754_services_table_add_cost_column/migration.sql
+++ b/server/prisma/migrations/20250810012754_services_table_add_cost_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "services" ADD COLUMN     "cost" DECIMAL(10,2);

--- a/server/prisma/migrations/20250810061417_is_primary_add_partial_unique_idx/migration.sql
+++ b/server/prisma/migrations/20250810061417_is_primary_add_partial_unique_idx/migration.sql
@@ -1,0 +1,4 @@
+--  Add partial unique index for isPrimary
+CREATE UNIQUE INDEX "one_primary_address_per_user"
+ON "addresses" ("user_id")
+WHERE "isPrimary" = TRUE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -109,9 +109,10 @@ model Technician {
 }
 
 model Service {
-  id          String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  name        String @db.VarChar(255)
-  description String @db.Text
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name        String   @db.VarChar(255)
+  description String   @db.Text
+  cost        Decimal? @db.Decimal(10, 2)
 
   technicianService TechnicianService[]
   Booking           Booking[]

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -90,6 +90,10 @@ model Address {
 
   user User @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
+  // NOTE: There is a partial unique index on ("user_id") where "isPrimary" = TRUE.
+  // See migration: CREATE UNIQUE INDEX "one_primary_address_per_user" ON "addresses" ("user_id") WHERE "isPrimary" = TRUE;
+  // This ensures only one primary address per user.
+
   @@unique([user_id, street, city, state, zip]) // Enforces no duplicate addresses per user
   @@map("addresses")
 }

--- a/server/src/controllers/addressController.ts
+++ b/server/src/controllers/addressController.ts
@@ -13,7 +13,8 @@ import {
 // Create Address
 const addAddress = asyncHandler(
   async (req: Request, res: Response, next: NextFunction) => {
-    const { street, city, state, zip, latitude, longitude } = req.body;
+    const { street, city, state, zip, latitude, longitude, isPrimary } =
+      req.body;
     const userId = (req.user as UserType).id;
 
     if (!userId) throw new AppError('Unauthorized', 401);
@@ -26,6 +27,7 @@ const addAddress = asyncHandler(
       zip,
       latitude,
       longitude,
+      isPrimary,
     });
 
     logger.info(`Address created for user ${userId}`);

--- a/server/src/services/addressService.ts
+++ b/server/src/services/addressService.ts
@@ -2,6 +2,29 @@ import prismaClient from '../config/prisma'; // Ensure your db connection is set
 import { Address } from '../../generated/prisma';
 import { AppError } from '../types/error';
 
+type CreateAddressInput = {
+  userId: string;
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+  latitude?: number;
+  longitude?: number;
+  isPrimary?: boolean;
+};
+
+type UpdateAddressInput = {
+  addressId: string;
+  userId: string;
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+  latitude: number | null;
+  longitude: number | null;
+  isPrimary?: boolean;
+};
+
 const getAddressesForUser = async (userId: string): Promise<Address[]> => {
   try {
     return await prismaClient.address.findMany({
@@ -16,16 +39,6 @@ const getAddressesForUser = async (userId: string): Promise<Address[]> => {
       500
     );
   }
-};
-
-type CreateAddressInput = {
-  userId: string;
-  street: string;
-  city: string;
-  state: string;
-  zip: string;
-  latitude?: number;
-  longitude?: number;
 };
 
 const createAddress = async ({
@@ -54,18 +67,6 @@ const createAddress = async ({
   } catch (error: any) {
     throw new Error(`Error creating user: ${error.message}`);
   }
-};
-
-type UpdateAddressInput = {
-  addressId: string;
-  userId: string;
-  street: string;
-  city: string;
-  state: string;
-  zip: string;
-  latitude: number | null;
-  longitude: number | null;
-  isPrimary?: boolean;
 };
 
 const updateUserAddress = async ({

--- a/server/src/services/addressService.ts
+++ b/server/src/services/addressService.ts
@@ -4,14 +4,16 @@ import { AppError } from '../types/error';
 
 const getAddressesForUser = async (userId: string): Promise<Address[]> => {
   try {
-    const addresses = await prismaClient.address.findMany({
+    return await prismaClient.address.findMany({
       where: { user_id: userId },
+      orderBy: [
+        { isPrimary: 'desc' }, // Primary first
+      ],
     });
-
-    return addresses;
   } catch (error: any) {
-    throw new Error(
-      `Error fetching addresses for userId ${userId}: ${error.message}`
+    throw new AppError(
+      `Error fetching addresses for userId ${userId}: ${error.message}`,
+      500
     );
   }
 };


### PR DESCRIPTION
### Description
1. Added `price` column to the `services` table.
2. Added constraint to the `addresses` table to ensure only one address per `user_id` can have `isPrimary = TRUE`.
3. Modified `updateUserAddress` and `createAddress` to enforce the logic introduced for `isPrimary` from  2.


### Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement

### How can this be tested (Please include visual illustrations if need be)
SET UP, sign in as Bob the builder: with the following
```json
{
    "email": "herewego@example.com",
    "password": "123123123"
}
```
And get the token and pass it as bearer token for each request we are going to make.

1. Added `price` column to the `services` table.
   - N/A
2. Added constraint to the `addresses` table to ensure only one address per `user_id` can have `isPrimary = TRUE`.
   - Go to supabase prod, `addresses` table, scroll all the way to the right and find user_id that start with `280f...`, copy it  <img width="2507" height="985" alt="image" src="https://github.com/user-attachments/assets/782f18f2-47f0-46a8-a9b0-2cf956be7a1f" />
   - apply filter so the tables only show the addresses for that `user_id`  <img width="2402" height="820" alt="image" src="https://github.com/user-attachments/assets/cc4c4abc-b5b1-47db-a3c3-375530a8b1e9" />
   - Scroll to  `is_primary` column, set Cartman Street as `false` and Kenny Street as `true`
   - once we have one `TRUE` value for an address we shouldn't be able to set another address' `is_ primary` as `TRUE`, test that by going to another row and set it's `is_primary` as `TRUE`, and you should see supabase complain to you about it.

3. Modified `updateUserAddress` and `createAddress` to enforce the logic introduced for `isPrimary` from  2.
   - Let's test and see if we can update a user's address via an endpoint that won't defy the constraint for `isPrimary`.
     - `at this point Kenny street should be `true` and Cartman street should be `false in terms of `isPrimary`
     -  let's grab the `id` for Cartman street and put it as a param + make a PATCH request to  `http://localhost:3000/api/users/addresses/:address_id`
     with the body of
      ```json
      {
        "street": "Cartman Start",
        "city": "south park",
        "state": "CO",
        "zip": "54321",
        "isPrimary": true
      }
      ```
        - After the request you should see Cartman Street being the primary address instead of Kenny Street
    - Now we test Creating a new address where we are going to set it as primary.
       - Make a POST request to `http://localhost:3000/api/users/addresses` with the following info:
           ```json
              {
               "street": "Stan Street", 
               "city": "south park",
               "state": "CO",
               "zip": "54321",
                "isPrimary": true
               }
            
        - Refresh the page in supabase, you now should see the new address being the primary and not any other
     




### Documentation update checklist
- [ ] I have made corresponding changes to the documentation
- [x] No documentation changes required


### Link to corresponding ticket or issue
- [Jira Link](https://yassahr.atlassian.net/jira/software/projects/TJN/boards/1?selectedIssue=TJN-89)