### PR TITLE
Delete manage-services route but left empty page in code

### DIFF
--- a/client/src/features/profile/components/AdminLinks.tsx
+++ b/client/src/features/profile/components/AdminLinks.tsx
@@ -10,12 +10,6 @@ const AdminLinks: React.FC = () => {
       >
         <span>Manage Techs</span>
       </Link>
-      <Link
-        to='/profile/manage-services'
-        className='text-md font-semibold py-5 border border-stone-300 rounded px-3 my-2 hover:bg-slate-300 focus:outline-2 focus:outline-offset-2 focus:outline-violet-500 active:bg-slate-300 duration-150'
-      >
-        <span>Manage Services</span>
-      </Link>
     </div>
   );
 };

--- a/client/src/features/profile/components/TechnicianLinks.tsx
+++ b/client/src/features/profile/components/TechnicianLinks.tsx
@@ -5,12 +5,6 @@ const TechnicianLinks: React.FC = () => {
   return (
     <div className='flex flex-row items-center justify-around'>
       <Link
-        to='/profile/manage-services'
-        className='text-md py-2 rounded-lg px-4 my-2 bg-primary-300 text-white hover:bg-secondary-300 focus:outline-2 focus:outline-offset-2 focus:outline-violet-500 active:bg-slate-300 duration-150'
-      >
-        <span className='text-2xl'>Manage Services</span>
-      </Link>
-      <Link
         to='/profile/manage-availability'
         className='text-md py-2 rounded-lg px-4 my-2 bg-primary-300 text-white hover:bg-secondary-300 focus:outline-2 focus:outline-offset-2 focus:outline-violet-500 active:bg-slate-300 duration-150'
       >

--- a/client/src/routes/routes.tsx
+++ b/client/src/routes/routes.tsx
@@ -14,7 +14,6 @@ const ScheduleServicePage = lazy(() => import('@/pages/ScheduleServicePage'));
 const CartPaymentPage = lazy(() => import('@/pages/CartPaymentPage'));
 const StatusPage = lazy(() => import('@/pages/StatusPage'));
 const RatingPage = lazy(() => import('@/pages/RatingPage'));
-const ManageServicesPage = lazy(() => import('@/pages/ManageServicesPage'));
 const ManageTechniciansPage = lazy(() => import('@/pages/ManageTechniciansPage'));
 // const ManageSchedulePage = lazy(() => import('@/pages/ManageSchedulePage'));
 const ProfilePage = lazy(() => import('@/pages/ProfilePage'));
@@ -49,7 +48,6 @@ const AppRoutes: React.FC = () => {
                 <Route index element={<ProfilePage />} />
                 <Route path='status' element={<StatusPage />} />
                 <Route path='rating' element={<RatingPage />} />
-                <Route path='manage-services' element={<ManageServicesPage />} />
                 <Route path='manage-technicians' element={<ManageTechniciansPage />} />
                 <Route path='/profile' element={<ProfilePage />} />
                 <Route path='manage-availability' element={<ManageAvailabilityPage />} />


### PR DESCRIPTION
### Description
- Remove route and links to manage-services page. Left Page in code just in case.

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement

### How can this be tested (Please include visual illustrations if need be)
- Login as a technician. No link for manage services should be seen:
<img width="1313" height="698" alt="image" src="https://github.com/user-attachments/assets/dcde0f96-73d5-424c-bd8e-f7394f29f22e" />

- Attempt to type in the url: http://localhost:5173/profile/manage-services
- Get a 404:
<img width="4320" height="2334" alt="image" src="https://github.com/user-attachments/assets/7091fcbd-2dd9-47b1-acbb-58c9c1280d4a" />


### Documentation update checklist
- [ ] I have made corresponding changes to the documentation
- [x] No documentation changes required


### Link to corresponding ticket or issue
- [Jira Link](https://yassahr.atlassian.net/browse/TJN-100)