### PR TITLE
Tjn 99 make technicians set availability in time blocks

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -36,6 +36,7 @@
         "pluralize": "^8.0.0",
         "react": "^18.3.1",
         "react-datepicker": "^8.4.0",
+        "react-day-picker": "^9.8.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.60.0",
         "react-router-dom": "^6.27.0",
@@ -347,6 +348,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.6",
@@ -1659,6 +1666,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
@@ -3678,6 +3686,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
     },
     "node_modules/dayjs": {
       "version": "1.11.13",
@@ -6207,6 +6221,27 @@
       "peerDependencies": {
         "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.8.1.tgz",
+      "integrity": "sha512-kMcLrp3PfN/asVJayVv82IjF3iLOOxuH5TNFWezX6lS/T8iVRFPTETpHl3TUSTH99IDMZLubdNPJr++rQctkEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,7 @@
     "pluralize": "^8.0.0",
     "react": "^18.3.1",
     "react-datepicker": "^8.4.0",
+    "react-day-picker": "^9.8.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.60.0",
     "react-router-dom": "^6.27.0",

--- a/client/src/components/technician/AvailableDayPicker.tsx
+++ b/client/src/components/technician/AvailableDayPicker.tsx
@@ -1,54 +1,75 @@
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Calendar } from '@/components/ui/calendar';
 
 export type DayT = {
-  value: string;
-  label: string;
-  dayOfWeek: number; // Optional, used for Sunday
+  // value: string;
+  // label: string;
+  // dayOfWeek: number; // Optional, used for Sunday
+  date: Date;
 };
 
-const daysOfWeek: DayT[] = [
-  { value: 'sunday', label: 'Sunday', dayOfWeek: 0 },
-  { value: 'monday', label: 'Monday', dayOfWeek: 1 },
-  { value: 'tuesday', label: 'Tuesday', dayOfWeek: 2 },
-  { value: 'wednesday', label: 'Wednesday', dayOfWeek: 3 },
-  { value: 'thursday', label: 'Thursday', dayOfWeek: 4 },
-  { value: 'friday', label: 'Friday', dayOfWeek: 5 },
-  { value: 'saturday', label: 'Saturday', dayOfWeek: 6 },
-];
+// const daysOfWeek: DayT[] = [
+//   { value: 'sunday', label: 'Sunday', dayOfWeek: 0 },
+//   { value: 'monday', label: 'Monday', dayOfWeek: 1 },
+//   { value: 'tuesday', label: 'Tuesday', dayOfWeek: 2 },
+//   { value: 'wednesday', label: 'Wednesday', dayOfWeek: 3 },
+//   { value: 'thursday', label: 'Thursday', dayOfWeek: 4 },
+//   { value: 'friday', label: 'Friday', dayOfWeek: 5 },
+//   { value: 'saturday', label: 'Saturday', dayOfWeek: 6 },
+// ];
 
 type AvailableDayPickerPropT = {
-  clickCallback?: (day: DayT) => void;
+  clickCallback?: (day: Date) => void;
 };
 
 export default function AvailableDayPicker({ clickCallback }: AvailableDayPickerPropT) {
-  const selections = daysOfWeek.map(dayOfWeek => {
-    return createDaySelection(dayOfWeek, clickCallback);
-  });
+  // const selections = daysOfWeek.map(dayOfWeek => {
+  //   return createDaySelection(dayOfWeek, clickCallback);
+  // });
 
   return (
-    <div>
-      <ToggleGroup variant='outline' type='multiple' className=' mx-auto'>
-        {selections}
-      </ToggleGroup>
+    <div className='flex justify-center'>
+      <Calendar
+        mode='multiple'
+        onDayClick={day => {
+          console.log('day', day);
+          if (clickCallback) {
+            clickCallback(day);
+          }
+        }}
+      />
     </div>
   );
 }
+// export default function AvailableDayPicker({ clickCallback }: AvailableDayPickerPropT) {
+//   const selections = daysOfWeek.map(dayOfWeek => {
+//     return createDaySelection(dayOfWeek, clickCallback);
+//   });
 
-function createDaySelection(day: DayT, clickCallback?: (day: DayT) => void) {
-  // const currentNumberOfDay = currentDate.getDay();
+//   return (
+//     <div>
+//       <ToggleGroup variant='outline' type='multiple' className=' mx-auto'>
+//         {selections}
+//       </ToggleGroup>
+//     </div>
+//   );
+// }
 
-  // Check if the day is in the past compared to the current date
+// function createDaySelection(day: DayT, clickCallback?: (day: DayT) => void) {
+//   // const currentNumberOfDay = currentDate.getDay();
 
-  return (
-    <ToggleGroupItem
-      onClick={() => clickCallback && clickCallback(day)}
-      key={String(day.label + day.value)}
-      value={day.value}
-      aria-label={`Toggle ${day.value}`}
-      className='p-3'
-      //
-    >
-      <span>{day.label}</span>
-    </ToggleGroupItem>
-  );
-}
+//   // Check if the day is in the past compared to the current date
+
+//   return (
+//     <ToggleGroupItem
+//       onClick={() => clickCallback && clickCallback(day)}
+//       key={String(day.label + day.value)}
+//       value={day.value}
+//       aria-label={`Toggle ${day.value}`}
+//       className='p-3'
+//       //
+//     >
+//       <span>{day.label}</span>
+//     </ToggleGroupItem>
+//   );
+// }

--- a/client/src/components/technician/AvailableDayPicker.tsx
+++ b/client/src/components/technician/AvailableDayPicker.tsx
@@ -32,7 +32,6 @@ export default function AvailableDayPicker({ clickCallback }: AvailableDayPicker
       <Calendar
         mode='multiple'
         onDayClick={day => {
-          console.log('day', day);
           if (clickCallback) {
             clickCallback(day);
           }

--- a/client/src/components/technician/AvailableTimePicker.tsx
+++ b/client/src/components/technician/AvailableTimePicker.tsx
@@ -19,6 +19,14 @@ export default function AvailableTimePicker({
   //if timeslots provided use them from props
   let timeSelections: JSX.Element[] = [];
 
+  const selectedTimes = selections
+    ? selections.filter(slot => slot.isSelected).map(slot => slot.value)
+    : undefined;
+
+  // useEffect(() => {
+  //   setSelectedTimes(() => selections.filter(slot => slot.isSelected).map(slot => slot.value));
+  // }, [selections]);
+
   //if range provided then create the timeslots for the range
   // if (range) {
   //   const timeSlotsForRange = createTimeSelectionFromRange(range.start, range.end);
@@ -42,7 +50,9 @@ export default function AvailableTimePicker({
     );
   });
 
-  const selectedTimes: SelectionsI[] = selections.filter(slot => slot.isSelected) || [];
+  // const selectedTimes: string[] = selections
+  //   .filter(slot => slot.isSelected)
+  //   .map(slot => slot.value);
 
   console.log('selectedTimes', selectedTimes);
 
@@ -52,7 +62,7 @@ export default function AvailableTimePicker({
         variant='outline'
         type='multiple'
         className='columns-3 w-11/12 mx-auto'
-        defaultValue={selectedTimes.map(slot => slot.value)}
+        value={selectedTimes.length > 0 ? selectedTimes : undefined}
       >
         {timeSelections}
       </ToggleGroup>

--- a/client/src/components/technician/AvailableTimePicker.tsx
+++ b/client/src/components/technician/AvailableTimePicker.tsx
@@ -1,68 +1,78 @@
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
-type TimeSlotT = {
-  date: Date;
-};
+interface SelectionsI {
+  option: string;
+  isSelected: boolean;
+  value: string;
+}
 
 type AvailableTimePickerPropT = {
-  timeSlots?: TimeSlotT[];
-  range?: { start: Date; end: Date };
-  clickCallback?: (time: Date) => void;
+  selections?: SelectionsI[];
+  // range?: { start: Date; end: Date };
+  clickCallback?: (time: string) => void;
 };
 
-export default function AvailableTimePicker({ range, clickCallback }: AvailableTimePickerPropT) {
+export default function AvailableTimePicker({
+  clickCallback,
+  selections = [],
+}: AvailableTimePickerPropT) {
   //if timeslots provided use them from props
   let timeSelections: JSX.Element[] = [];
 
   //if range provided then create the timeslots for the range
-  if (range) {
-    const timeSlotsForRange = createTimeSelectionFromRange(range.start, range.end);
-    timeSelections = timeSlotsForRange.map(time => {
-      return timeSelectionButton(time, clickCallback);
-    });
-  }
+  // if (range) {
+  //   const timeSlotsForRange = createTimeSelectionFromRange(range.start, range.end);
+  //   timeSelections = timeSlotsForRange.map(time => {
+  //     return timeSelectionButton(time, clickCallback);
+  //   });
+  // }
 
-  return <div className='columns-3 w-11/12 mx-auto'>{timeSelections}</div>;
-}
-
-//generate the JSX for the date passed in
-function timeSelectionButton(time: Date, callback?: (time: Date) => void) {
-  const timeString = time.toLocaleTimeString();
-  time.setMinutes(0);
-
-  const hour = timeString.split(':').slice(0, 2).join(':');
-  const amPm = timeString.split(' ')[1];
-
-  return (
-    <ToggleGroup key={time.toUTCString()} variant='outline' type='multiple' className='w-full'>
+  timeSelections = selections.map(slot => {
+    return (
       <ToggleGroupItem
         onClick={() => {
-          if (callback) callback(time);
+          if (clickCallback) clickCallback(slot.value);
         }}
-        value={hour}
+        value={slot.value}
         aria-label='Toggle'
+        className='border-3'
       >
-        <span>{hour}</span>
-        <span>{amPm}</span>
+        <span>{slot.option}</span>
       </ToggleGroupItem>
-    </ToggleGroup>
+    );
+  });
+
+  const selectedTimes: SelectionsI[] = selections.filter(slot => slot.isSelected) || [];
+
+  console.log('selectedTimes', selectedTimes);
+
+  return (
+    <div className=''>
+      <ToggleGroup
+        variant='outline'
+        type='multiple'
+        className='columns-3 w-11/12 mx-auto'
+        defaultValue={selectedTimes.map(slot => slot.value)}
+      >
+        {timeSelections}
+      </ToggleGroup>
+    </div>
   );
 }
 
-//create array of dates for start and end range one hour apart
-function createTimeSelectionFromRange(start: Date, end: Date) {
-  if (!start || !end) return [];
-
-  const currentDate = new Date(start);
-  currentDate.setMinutes(0);
-  const times: Date[] = [];
-
-  while (currentDate <= end) {
-    times.push(new Date(currentDate));
-
-    currentDate.setHours(currentDate.getHours() + 1);
-    currentDate.setMinutes(0);
-  }
-
-  return times;
-}
+// //generate the JSX for the date passed in
+// function timeSelectionButton(time: string, callback?: (time: string) => void) {
+//   return (
+//     <ToggleGroup key={time} variant='outline' type='multiple' className='w-full'>
+//       <ToggleGroupItem
+//         onClick={() => {
+//           if (callback) callback(time);
+//         }}
+//         value={time}
+//         aria-label='Toggle'
+//       >
+//         <span>{time}</span>
+//       </ToggleGroupItem>
+//     </ToggleGroup>
+//   );
+// }

--- a/client/src/components/technician/AvailableTimePicker.tsx
+++ b/client/src/components/technician/AvailableTimePicker.tsx
@@ -7,35 +7,34 @@ interface SelectionsI {
 }
 
 type AvailableTimePickerPropT = {
-  selections?: SelectionsI[];
-  // range?: { start: Date; end: Date };
+  selections?: SelectionsI[]; //options user can select
   clickCallback?: (time: string) => void;
+  editAll?: boolean;
 };
 
 export default function AvailableTimePicker({
   clickCallback,
   selections = [],
+  editAll,
 }: AvailableTimePickerPropT) {
-  //if timeslots provided use them from props
+  //ui buttons for user to select time slots
   let timeSelections: JSX.Element[] = [];
 
-  const selectedTimes = selections.filter(slot => slot.isSelected).map(slot => slot.value);
+  //filter by seleted items then return string array of the values to set as seleted in ui
+  const filteredSelections = selections.filter(slot => slot.isSelected);
 
-  // useEffect(() => {
-  //   setSelectedTimes(() => selections.filter(slot => slot.isSelected).map(slot => slot.value));
-  // }, [selections]);
-
-  //if range provided then create the timeslots for the range
-  // if (range) {
-  //   const timeSlotsForRange = createTimeSelectionFromRange(range.start, range.end);
-  //   timeSelections = timeSlotsForRange.map(time => {
-  //     return timeSelectionButton(time, clickCallback);
-  //   });
-  // }
+  //set up selected options by getting values for component to use
+  const selectedTimes =
+    filteredSelections.length > 0
+      ? filteredSelections.map(slot => slot.value)
+      : editAll
+        ? undefined
+        : [];
 
   timeSelections = selections.map(slot => {
     return (
       <ToggleGroupItem
+        key={slot.value}
         onClick={() => {
           if (clickCallback) clickCallback(slot.value);
         }}
@@ -48,19 +47,13 @@ export default function AvailableTimePicker({
     );
   });
 
-  // const selectedTimes: string[] = selections
-  //   .filter(slot => slot.isSelected)
-  //   .map(slot => slot.value);
-
-  console.log('selectedTimes', selectedTimes);
-
   return (
     <div className=''>
       <ToggleGroup
         variant='outline'
         type='multiple'
         className='columns-3 w-11/12 mx-auto'
-        value={selectedTimes.length > 0 ? selectedTimes : []}
+        value={selectedTimes}
       >
         {timeSelections}
       </ToggleGroup>

--- a/client/src/components/technician/AvailableTimePicker.tsx
+++ b/client/src/components/technician/AvailableTimePicker.tsx
@@ -19,9 +19,7 @@ export default function AvailableTimePicker({
   //if timeslots provided use them from props
   let timeSelections: JSX.Element[] = [];
 
-  const selectedTimes = selections
-    ? selections.filter(slot => slot.isSelected).map(slot => slot.value)
-    : undefined;
+  const selectedTimes = selections.filter(slot => slot.isSelected).map(slot => slot.value);
 
   // useEffect(() => {
   //   setSelectedTimes(() => selections.filter(slot => slot.isSelected).map(slot => slot.value));
@@ -62,7 +60,7 @@ export default function AvailableTimePicker({
         variant='outline'
         type='multiple'
         className='columns-3 w-11/12 mx-auto'
-        value={selectedTimes.length > 0 ? selectedTimes : undefined}
+        value={selectedTimes.length > 0 ? selectedTimes : []}
       >
         {timeSelections}
       </ToggleGroup>

--- a/client/src/components/technician/AvailableTimePicker.tsx
+++ b/client/src/components/technician/AvailableTimePicker.tsx
@@ -8,12 +8,12 @@ interface SelectionsI {
 
 type AvailableTimePickerPropT = {
   selections?: SelectionsI[]; //options user can select
-  clickCallback?: (time: string) => void;
+  valueChangeCallback?: (time: string[]) => void;
   editAll?: boolean;
 };
 
 export default function AvailableTimePicker({
-  clickCallback,
+  valueChangeCallback,
   selections = [],
   editAll,
 }: AvailableTimePickerPropT) {
@@ -35,9 +35,9 @@ export default function AvailableTimePicker({
     return (
       <ToggleGroupItem
         key={slot.value}
-        onClick={() => {
-          if (clickCallback) clickCallback(slot.value);
-        }}
+        // onClick={() => {
+        //   if (valueChangeCallback) valueChangeCallback(slot.value);
+        // }}
         value={slot.value}
         aria-label='Toggle'
         className='border-3'
@@ -54,6 +54,9 @@ export default function AvailableTimePicker({
         type='multiple'
         className='columns-3 w-11/12 mx-auto'
         value={selectedTimes}
+        onValueChange={value => {
+          if (valueChangeCallback) valueChangeCallback(value);
+        }}
       >
         {timeSelections}
       </ToggleGroup>

--- a/client/src/components/technician/EditDay.tsx
+++ b/client/src/components/technician/EditDay.tsx
@@ -1,0 +1,27 @@
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
+
+export default function EditDay({
+  selections,
+  onSelected,
+}: {
+  selections: Date[];
+  onSelected?: (day: Date) => void;
+}) {
+  return (
+    <div>
+      <ToggleGroup variant='outline' type='single' className=' mx-auto'>
+        {selections.map(day => (
+          <ToggleGroupItem
+            key={String(day.getTime())}
+            value={day.toDateString()}
+            aria-label={`Toggle ${day.toDateString()}`}
+            className='p-3'
+            onClick={() => onSelected && onSelected(day)}
+          >
+            {day.toDateString()}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+}

--- a/client/src/components/technician/TechAvailabilityForm.tsx
+++ b/client/src/components/technician/TechAvailabilityForm.tsx
@@ -32,15 +32,28 @@ export default function TechAvailabilityForm() {
     //no day selected then update all days
     if (!dayToEdit) {
       setSchedule(prev => {
-        const updated = prev.map(day => ({ ...day, timeBlocks: [...day.timeBlocks, time] }));
-        return updated;
+        const updatedSchedule = prev.map(day => {
+          //filter times out of day
+          const hasTime = day.timeBlocks.includes(time);
+          if (hasTime) {
+            return { ...day, timeBlocks: [...day.timeBlocks.filter(t => t !== time)] };
+          } else {
+            return { ...day, timeBlocks: [...day.timeBlocks, time] };
+          }
+        });
+        return updatedSchedule;
       });
     }
 
     setSchedule(prev => {
       const updated = prev.map(day => {
         if (day.date.getTime() === dayToEdit?.getTime()) {
-          return { ...day, timeBlocks: [...day.timeBlocks, time] };
+          const hasTime = day.timeBlocks.includes(time);
+          if (hasTime) {
+            return { ...day, timeBlocks: [...day.timeBlocks.filter(t => t !== time)] };
+          } else {
+            return { ...day, timeBlocks: [...day.timeBlocks, time] };
+          }
         }
         return day;
       });

--- a/client/src/components/technician/TechAvailabilityForm.tsx
+++ b/client/src/components/technician/TechAvailabilityForm.tsx
@@ -3,6 +3,7 @@ import AvailableDayPicker from './AvailableDayPicker';
 import AvailableTimePicker from './AvailableTimePicker';
 import { Button } from '../ui';
 import EditDay from './EditDay';
+import LoadingIndicator from '../LoadingIndicator';
 
 interface DaySchedule {
   date: Date;
@@ -80,17 +81,15 @@ export default function TechAvailabilityForm() {
   const AvailableTimePickerOptions = getAvailableTimePickerOptions(dayToEdit, schedule);
 
   return (
-    <section>
+    <section className='relative'>
       <form action='' onSubmit={handleSubmit} className=''>
         <section>
           <h2 className='text-4xl'>Set Your Availability</h2>
         </section>
-
         <section className='border-2 border-gray-200 mb-4 pb-4'>
           <h3 className='font-bold'>Select days available</h3>
           <AvailableDayPicker clickCallback={handleDayClick} />
         </section>
-
         {/* displays selected days and can togle single selection to edit  */}
         <section className='flex items-center justify-center'>
           <div className='bg-accent p-2 rounded-2xl'>
@@ -102,7 +101,6 @@ export default function TechAvailabilityForm() {
             {!dayToEdit && <div>Editing: All</div>}
           </div>
         </section>
-
         <section>
           <h3 className='font-bold'>Select time available</h3>
 
@@ -112,12 +110,14 @@ export default function TechAvailabilityForm() {
             selections={AvailableTimePickerOptions}
           />
         </section>
-
         <section className='mt-4'>
           <Button type='submit'>Confirm availability</Button>
         </section>
 
-        <section></section>
+        {/* <section className=' flex justify-center items-center'>
+          <div className='absolute h-screen bg-gray-600 w-full opacity-70 top-0 z-50'></div>
+          <LoadingIndicator size='lg' />
+        </section> */}
       </form>
     </section>
   );

--- a/client/src/components/technician/TechAvailabilityForm.tsx
+++ b/client/src/components/technician/TechAvailabilityForm.tsx
@@ -62,7 +62,6 @@ export default function TechAvailabilityForm() {
   };
 
   const handleDayClick = (day: Date) => {
-    console.log('Selected day:', day.getTime());
     setSchedule(prev => {
       if (prev.length === 0) {
         return [{ date: day, timeBlocks: [] }];
@@ -110,13 +109,15 @@ export default function TechAvailabilityForm() {
           <AvailableDayPicker clickCallback={handleDayClick} />
         </section>
 
+        {/* displays selected days and can togle single selection to edit  */}
         <section className='flex items-center justify-center'>
           <div className='bg-accent p-2 rounded-2xl'>
             <EditDay
               onSelected={handleDayToEdit}
               selections={schedule.map(scheduleForDay => scheduleForDay.date)}
             />
-            {dayToEdit && <div>{dayToEdit.toLocaleDateString()}</div>}
+            {dayToEdit && <div>Editing: {dayToEdit.toLocaleDateString()} only</div>}
+            {!dayToEdit && <div>Editing: All</div>}
           </div>
         </section>
 
@@ -124,6 +125,7 @@ export default function TechAvailabilityForm() {
           <h3 className='font-bold'>Select time available</h3>
 
           <AvailableTimePicker
+            editAll={!dayToEdit}
             clickCallback={handleTimeClick}
             selections={AvailableTimePickerOptions}
           />
@@ -139,6 +141,7 @@ export default function TechAvailabilityForm() {
   );
 }
 
+//set the time selections as selected if day is being edited or return default options
 function getAvailableTimePickerOptions(dayToEdit: Date | null, schedule: DaySchedule[]) {
   const options = [
     { option: 'Morning', isSelected: false, value: 'morning' },
@@ -146,21 +149,22 @@ function getAvailableTimePickerOptions(dayToEdit: Date | null, schedule: DaySche
     { option: 'Evening', isSelected: false, value: 'evening' },
   ];
 
+  //return default options
   if (!dayToEdit) return options;
 
+  //find schedule for day
   const daySchedule = schedule.find(day => day.date.getTime() === dayToEdit.getTime());
+
+  //no schedule found for day return default options
   if (!daySchedule) return options;
 
-  console.log('daySchedule found', daySchedule);
-
+  //update schedule of day found
   const updatedOptions = options.map(option => {
     if (daySchedule.timeBlocks.includes(option.value)) {
       return { ...option, isSelected: true };
     }
     return option;
   });
-
-  console.log('updatedOptions', updatedOptions);
 
   return updatedOptions;
 }

--- a/client/src/components/technician/TechAvailabilityForm.tsx
+++ b/client/src/components/technician/TechAvailabilityForm.tsx
@@ -140,8 +140,6 @@ export default function TechAvailabilityForm() {
 }
 
 function getAvailableTimePickerOptions(dayToEdit: Date | null, schedule: DaySchedule[]) {
-  // console.log('dayToEdit', dayToEdit);
-  // console.log('schedule', schedule);
   const options = [
     { option: 'Morning', isSelected: false, value: 'morning' },
     { option: 'Afternoon', isSelected: false, value: 'afternoon' },

--- a/client/src/components/technician/TechAvailabilityForm.tsx
+++ b/client/src/components/technician/TechAvailabilityForm.tsx
@@ -10,36 +10,20 @@ interface DaySchedule {
 }
 
 export default function TechAvailabilityForm() {
-  // const currentDate = new Date();
-  // currentDate.setHours(6, 0, 0, 0); // Set the current date to today at 6 AM
-
-  // Ensure the current date is set to the nearest hour and range is 14 hours 6am to 8pm
-  // const timeRange = {
-  //   start: new Date(currentDate),
-  //   end: new Date(new Date().setHours(currentDate.getHours() + 14)), // 14 hours later,
-  // };
-
   const [schedule, setSchedule] = useState<DaySchedule[]>([]);
 
-  // const [selectedDays, setSelectedDays] = useState<Date[]>([]); //handles day selection
-  // const [selectedTimes, setSelectedTimes] = useState<string[]>([]); //handles the time
   const [dayToEdit, setDayToEdit] = useState<Date | null>(null);
 
   // set the time technician is available
-  const handleTimeClick = (time: string) => {
-    console.log('time click', time);
+  const handleTimeClick = (timeSlots: string[]) => {
+    // console.log('time click', timeSlots);
 
     //no day selected then update all days
     if (!dayToEdit) {
       setSchedule(prev => {
         const updatedSchedule = prev.map(day => {
           //filter times out of day
-          const hasTime = day.timeBlocks.includes(time);
-          if (hasTime) {
-            return { ...day, timeBlocks: [...day.timeBlocks.filter(t => t !== time)] };
-          } else {
-            return { ...day, timeBlocks: [...day.timeBlocks, time] };
-          }
+          return { ...day, timeBlocks: timeSlots };
         });
         return updatedSchedule;
       });
@@ -48,12 +32,8 @@ export default function TechAvailabilityForm() {
     setSchedule(prev => {
       const updated = prev.map(day => {
         if (day.date.getTime() === dayToEdit?.getTime()) {
-          const hasTime = day.timeBlocks.includes(time);
-          if (hasTime) {
-            return { ...day, timeBlocks: [...day.timeBlocks.filter(t => t !== time)] };
-          } else {
-            return { ...day, timeBlocks: [...day.timeBlocks, time] };
-          }
+          day.timeBlocks = timeSlots;
+          return day;
         }
         return day;
       });
@@ -68,7 +48,6 @@ export default function TechAvailabilityForm() {
       }
 
       // filter by label
-      // let list = prev.filter(d => d.value !== day.value);
       let list = prev.filter(scheduleForDay => scheduleForDay.date.getTime() !== day.getTime());
 
       //if list is same size then day was not in list, add it
@@ -80,6 +59,7 @@ export default function TechAvailabilityForm() {
     });
   };
 
+  //sets the day to apply changes
   const handleDayToEdit = (day: Date) => {
     setDayToEdit(prev => (prev === day ? null : day));
   };
@@ -87,10 +67,12 @@ export default function TechAvailabilityForm() {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const scheduledDays = schedule.map(day => ({
-      availableDate: day.date,
-      timeBlock: day.timeBlocks,
-    }));
+    const scheduledDays = schedule
+      .map(day => ({
+        availableDate: day.date,
+        timeBlock: day.timeBlocks,
+      }))
+      .filter(day => day.timeBlock.length > 0);
 
     console.log('Schedule submitted:', scheduledDays);
   };
@@ -126,7 +108,7 @@ export default function TechAvailabilityForm() {
 
           <AvailableTimePicker
             editAll={!dayToEdit}
-            clickCallback={handleTimeClick}
+            valueChangeCallback={handleTimeClick}
             selections={AvailableTimePickerOptions}
           />
         </section>

--- a/client/src/components/ui/calendar.tsx
+++ b/client/src/components/ui/calendar.tsx
@@ -1,0 +1,211 @@
+import * as React from "react"
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from "lucide-react"
+import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { Button, buttonVariants } from "@/components/ui/button"
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout = "label",
+  buttonVariant = "ghost",
+  formatters,
+  components,
+  ...props
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>["variant"]
+}) {
+  const defaultClassNames = getDefaultClassNames()
+
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(
+        "bg-background group/calendar p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className
+      )}
+      captionLayout={captionLayout}
+      formatters={{
+        formatMonthDropdown: (date) =>
+          date.toLocaleString("default", { month: "short" }),
+        ...formatters,
+      }}
+      classNames={{
+        root: cn("w-fit", defaultClassNames.root),
+        months: cn(
+          "flex gap-4 flex-col md:flex-row relative",
+          defaultClassNames.months
+        ),
+        month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
+        nav: cn(
+          "flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between",
+          defaultClassNames.nav
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+          defaultClassNames.button_previous
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
+          defaultClassNames.button_next
+        ),
+        month_caption: cn(
+          "flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)",
+          defaultClassNames.month_caption
+        ),
+        dropdowns: cn(
+          "w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5",
+          defaultClassNames.dropdowns
+        ),
+        dropdown_root: cn(
+          "relative has-focus:border-ring border border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] rounded-md",
+          defaultClassNames.dropdown_root
+        ),
+        dropdown: cn(
+          "absolute bg-popover inset-0 opacity-0",
+          defaultClassNames.dropdown
+        ),
+        caption_label: cn(
+          "select-none font-medium",
+          captionLayout === "label"
+            ? "text-sm"
+            : "rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5",
+          defaultClassNames.caption_label
+        ),
+        table: "w-full border-collapse",
+        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekday: cn(
+          "text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none",
+          defaultClassNames.weekday
+        ),
+        week: cn("flex w-full mt-2", defaultClassNames.week),
+        week_number_header: cn(
+          "select-none w-(--cell-size)",
+          defaultClassNames.week_number_header
+        ),
+        week_number: cn(
+          "text-[0.8rem] select-none text-muted-foreground",
+          defaultClassNames.week_number
+        ),
+        day: cn(
+          "relative w-full h-full p-0 text-center [&:first-child[data-selected=true]_button]:rounded-l-md [&:last-child[data-selected=true]_button]:rounded-r-md group/day aspect-square select-none",
+          defaultClassNames.day
+        ),
+        range_start: cn(
+          "rounded-l-md bg-accent",
+          defaultClassNames.range_start
+        ),
+        range_middle: cn("rounded-none", defaultClassNames.range_middle),
+        range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
+        today: cn(
+          "bg-accent text-accent-foreground rounded-md data-[selected=true]:rounded-none",
+          defaultClassNames.today
+        ),
+        outside: cn(
+          "text-muted-foreground aria-selected:text-muted-foreground",
+          defaultClassNames.outside
+        ),
+        disabled: cn(
+          "text-muted-foreground opacity-50",
+          defaultClassNames.disabled
+        ),
+        hidden: cn("invisible", defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Root: ({ className, rootRef, ...props }) => {
+          return (
+            <div
+              data-slot="calendar"
+              ref={rootRef}
+              className={cn(className)}
+              {...props}
+            />
+          )
+        },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === "left") {
+            return (
+              <ChevronLeftIcon className={cn("size-4", className)} {...props} />
+            )
+          }
+
+          if (orientation === "right") {
+            return (
+              <ChevronRightIcon
+                className={cn("size-4", className)}
+                {...props}
+              />
+            )
+          }
+
+          return (
+            <ChevronDownIcon className={cn("size-4", className)} {...props} />
+          )
+        },
+        DayButton: CalendarDayButton,
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
+                {children}
+              </div>
+            </td>
+          )
+        },
+        ...components,
+      }}
+      {...props}
+    />
+  )
+}
+
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  ...props
+}: React.ComponentProps<typeof DayButton>) {
+  const defaultClassNames = getDefaultClassNames()
+
+  const ref = React.useRef<HTMLButtonElement>(null)
+  React.useEffect(() => {
+    if (modifiers.focused) ref.current?.focus()
+  }, [modifiers.focused])
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString()}
+      data-selected-single={
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md [&>span]:text-xs [&>span]:opacity-70",
+        defaultClassNames.day,
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Calendar, CalendarDayButton }

--- a/client/src/components/ui/toggle.tsx
+++ b/client/src/components/ui/toggle.tsx
@@ -7,13 +7,13 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary-500  data-[state=on]:text-white [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
   {
     variants: {
       variant: {
         default: 'bg-transparent',
         outline:
-          'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
+          'border border-input bg-transparent shadow-xs hover:bg-accent hover:bg-slate-200  hover:text-black',
       },
       size: {
         default: 'h-9 px-2 min-w-9',

--- a/client/src/features/technicians/api/index.ts
+++ b/client/src/features/technicians/api/index.ts
@@ -1,1 +1,1 @@
-export { fetchTechnicians } from './techniciansApi';
+export * from './techniciansApi';

--- a/client/src/features/technicians/api/techniciansApi.ts
+++ b/client/src/features/technicians/api/techniciansApi.ts
@@ -1,5 +1,6 @@
 import { axiosInstance } from '@/api';
 import { Technician } from '@/features/technicians';
+import { TechnicianAvailabilityI } from '../types/Technician';
 
 const url = '/technicians';
 
@@ -8,6 +9,7 @@ export const fetchTechnicians = async (): Promise<Technician[]> => {
   return response.data;
 };
 
-export const updateAvailability = async (id: string, availability: any): Promise<void> => {
-  await axiosInstance.post(`${url}/technicians/${id}/availabilities`, availability);
+export const updateAvailability = async (id: string, availability: TechnicianAvailabilityI[]) => {
+  const res = await axiosInstance.post(`${url}/${id}/availabilities`, availability);
+  return res.data;
 };

--- a/client/src/features/technicians/api/techniciansApi.ts
+++ b/client/src/features/technicians/api/techniciansApi.ts
@@ -7,3 +7,7 @@ export const fetchTechnicians = async (): Promise<Technician[]> => {
   const response = await axiosInstance.get(url);
   return response.data;
 };
+
+export const updateAvailability = async (id: string, availability: any): Promise<void> => {
+  await axiosInstance.post(`${url}/technicians/${id}/availabilities`, availability);
+};

--- a/client/src/features/technicians/api/techniciansApi.ts
+++ b/client/src/features/technicians/api/techniciansApi.ts
@@ -9,7 +9,15 @@ export const fetchTechnicians = async (): Promise<Technician[]> => {
   return response.data;
 };
 
-export const updateAvailability = async (id: string, availability: TechnicianAvailabilityI[]) => {
-  const res = await axiosInstance.post(`${url}/${id}/availabilities`, availability);
+export const updateAvailability = async (
+  token: string,
+  id: string,
+  availability: TechnicianAvailabilityI[]
+) => {
+  const res = await axiosInstance.post(`${url}/${id}/availabilities`, availability, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
   return res.data;
 };

--- a/client/src/features/technicians/hooks/useUpdateTechAvailabilities.ts
+++ b/client/src/features/technicians/hooks/useUpdateTechAvailabilities.ts
@@ -4,7 +4,12 @@ import { TechnicianAvailabilityI } from '../types/Technician';
 
 export const useUpdateTechAvailability = (userToken: string) => {
   return useMutation({
-    mutationFn: (availability: TechnicianAvailabilityI[]) =>
-      updateAvailability(userToken, availability),
+    mutationFn: async ({
+      availability,
+      userId,
+    }: {
+      availability: TechnicianAvailabilityI[];
+      userId: string;
+    }) => await updateAvailability(userToken, userId, availability),
   });
 };

--- a/client/src/features/technicians/hooks/useUpdateTechAvailabilities.ts
+++ b/client/src/features/technicians/hooks/useUpdateTechAvailabilities.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { updateAvailability } from '@/features/technicians/api';
+import { TechnicianAvailabilityI } from '../types/Technician';
+
+export const useUpdateTechAvailability = (userToken: string) => {
+  return useMutation({
+    mutationFn: (availability: TechnicianAvailabilityI[]) =>
+      updateAvailability(userToken, availability),
+  });
+};

--- a/client/src/features/technicians/types/Technician.ts
+++ b/client/src/features/technicians/types/Technician.ts
@@ -5,3 +5,8 @@ export interface Technician {
   current_rating: number;
   user: User;
 }
+
+export interface TechnicianAvailabilityI {
+  availableDate: string;
+  timeBlock: string[];
+}


### PR DESCRIPTION
### Description
- form for tech availability follows correct format for displaying morning, afternoon , evening
- can edit all days or pick individual days to edit timeblock

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement

### How can this be tested (Please include visual illustrations if need be)
- login with tech profile
- got to profile page  and click manage availability 
- 
<img width="927" height="1099" alt="image" src="https://github.com/user-attachments/assets/5d056605-7305-400b-baa2-342bf68aecc1" />

<img width="1016" height="934" alt="image" src="https://github.com/user-attachments/assets/93d33963-95f7-4c44-9ccf-abe10b043e96" />


### Documentation update checklist
- [ ] I have made corresponding changes to the documentation
- [ ] No documentation changes required


### Link to corresponding ticket or issue
- [Jira Link](https://yassahr.atlassian.net/jira/software/projects/TJN/boards/1)